### PR TITLE
Some minor grammar and styling changes

### DIFF
--- a/flexible-templates-for-acf-pro/class-flexible-templates.php
+++ b/flexible-templates-for-acf-pro/class-flexible-templates.php
@@ -143,7 +143,7 @@ if( ! class_exists('Flexible_Templates') ) :
 			$depricated_templates = acfft_get_templates( '' );
 
 			$out = '<div class="acfft_flexible_templates button-primary">';
-				$out .= '<div class="selected">'.__("Saved Template's", 'acf-ft').'</div>';
+				$out .= '<div class="selected">'.__("Saved Templates", 'acf-ft').'</div>';
 
 				if( $templates || $depricated_templates ){
 					//sorting alphabetically
@@ -183,7 +183,7 @@ if( ! class_exists('Flexible_Templates') ) :
 					$out .= '</div>';
 				}else{
 					$out .= '<div class="acfft-dropdown">';
-						$out .= '<div class="info">'.__("To save template, scroll to the bottom of your flexible layout, input name and hit save button.", "acf-ft").'</div>';
+						$out .= '<div class="info">'.__("To save a template, scroll to the bottom of your flexible layout, input name and hit save button.", "acf-ft").'</div>';
 					$out .= '</div>';
 				}
 

--- a/flexible-templates-for-acf-pro/css/style.css
+++ b/flexible-templates-for-acf-pro/css/style.css
@@ -1,17 +1,17 @@
-.acf-flexible-content li.acf-ft-save-wrap{
+.acf-flexible-content .acf-ft-save-wrap{
     float: left;
     margin-left: 0;
     width: 50%;
     min-width: 400px;
 }
 
-.acf-flexible-content li.acf-ft-save-wrap .acf-ft-template-name{
+.acf-flexible-content .acf-ft-save-wrap .acf-ft-template-name{
     float: left;
     width: 62%;
     margin-right: 1%;
 }
 
-.acf-flexible-content li.acf-ft-save-wrap .acf-ft-save{
+.acf-flexible-content .acf-ft-save-wrap .acf-ft-save{
     float: left;
     width: 37%;
     text-align: center;

--- a/flexible-templates-for-acf-pro/js/script.js
+++ b/flexible-templates-for-acf-pro/js/script.js
@@ -11,11 +11,11 @@ jQuery.expr[':'].parents = function(a,i,m){
 
 		//if( $('.acf-field-flexible-content').length ){
 
-			var button = '<li class="acf-ft-save-wrap">';
+			var button = '<div class="acf-ft-save-wrap">';
 				button += '<input type="text" class="acf-ft-template-name" value="" placeholder="'+acfft.tpl_name+'">';
 					button += '<a href="#save_template" class="acf-ft-save acf-button button button-secondary">'+acfft.tpl_save+'</a>';
 					button += '<div class="acf-ft-save-error"></div>';
-				button += '</li>';
+				button += '</div>';
 
 			$('.acf-field-flexible-content .values').next().prepend( button );
 

--- a/flexible-templates-for-acf-pro/js/script.js
+++ b/flexible-templates-for-acf-pro/js/script.js
@@ -115,7 +115,11 @@ jQuery.expr[':'].parents = function(a,i,m){
 			}
 
 			$('.acfft-remove').on('click', function(){
-
+				
+				if (!window.confirm("Are you sure you wish to delete this template?")) { 
+				  return;
+				}
+				
 				var self = this;
 				var template_name = $(this).data('value');
 


### PR DESCRIPTION
I have fixed the following grammar errors:

- "Saved Templates" does not need an apostraphe
- Added the word 'a' in the sentence "To save a template..."

And the following styling errors:

- I changed the `<li>` to a `<div>` to avoid a bullet showing in the backend.